### PR TITLE
'analytic_kl' argument has been removed

### DIFF
--- a/sounds_deep/contrib/experiments/train_nvvae.py
+++ b/sounds_deep/contrib/experiments/train_nvvae.py
@@ -148,8 +148,7 @@ model(
     labeled_data_ph,
     label_ph,
     temperature_ph,
-    classification_loss_coeff=args.classification_loss_coeff,
-    analytic_kl=True)
+    classification_loss_coeff=args.classification_loss_coeff)
 
 num_samples = 16
 nv_sample_ph = tf.placeholder_with_default(


### PR DESCRIPTION
The analytic_kl argument seems have been removed from the declaration of ```nvvae.NamedLatentVAE._build()``` .
Remaining that argument in the train_nvvae.py will cause: 
```
Traceback (most recent call last):
  File "/work/scott/tyao/sounds-deep/sounds_deep/contrib/experiments/train_nvvae.py", line 161, in <module>
    analytic_kl=True)
  File "/home/scott/tyao/.conda/envs/sounds-deep/lib/python3.6/site-packages/sonnet/python/modules/base.py", line 389, in __call__
    outputs, subgraph_name_scope = self._template(*args, **kwargs)
  File "/home/scott/tyao/.conda/envs/sounds-deep/lib/python3.6/site-packages/tensorflow/python/ops/template.py", line 455, in __call__
    result = self._call_func(args, kwargs)
  File "/home/scott/tyao/.conda/envs/sounds-deep/lib/python3.6/site-packages/tensorflow/python/ops/template.py", line 406, in _call_func
    result = self._func(*args, **kwargs)
  File "/home/scott/tyao/.conda/envs/sounds-deep/lib/python3.6/site-packages/sonnet/python/modules/base.py", line 246, in _build_wrapper
    output = self._build(*args, **kwargs)
TypeError: _build() got an unexpected keyword argument 'analytic_kl'

originally defined at:
  File "/work/scott/tyao/sounds-deep/sounds_deep/contrib/experiments/train_nvvae.py", line 142, in <module>
    output_dist_fn=output_distribution_fn)
  File "/work/scott/tyao/sounds-deep/sounds_deep/contrib/models/nvvae.py", line 20, in __init__
    super(NamedLatentVAE, self).__init__(name=name)
  File "/home/scott/tyao/.conda/envs/sounds-deep/lib/python3.6/site-packages/sonnet/python/modules/base.py", line 215, in __init__
    custom_getter_=self._custom_getter)
  File "/home/scott/tyao/.conda/envs/sounds-deep/lib/python3.6/site-packages/tensorflow/python/ops/template.py", line 153, in make_template
    **kwargs)

```